### PR TITLE
Paramaterized functional testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ unittest:
 	@tox -e unit
 
 functional: build
-	@tox -e functional
+	@PYTEST_KEEP_MODEL=$(PYTEST_KEEP_MODEL) tox -e functional
 
 build:
 	@echo "Building charm to base directory $(JUJU_REPOSITORY)"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,10 @@ unittest:
 	@tox -e unit
 
 functional: build
-	@PYTEST_KEEP_MODEL=$(PYTEST_KEEP_MODEL) tox -e functional
+	@PYTEST_KEEP_MODEL=$(PYTEST_KEEP_MODEL) \
+	    PYTEST_CLOUD_NAME=$(PYTEST_CLOUD_NAME) \
+	    PYTEST_CLOUD_REGION=$(PYTEST_CLOUD_REGION) \
+	    tox -e functional
 
 build:
 	@echo "Building charm to base directory $(JUJU_REPOSITORY)"

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -62,7 +62,10 @@ async def controller():
 async def model(controller):
     '''This model lives only for the duration of the test'''
     model_name = "functest-{}".format(str(uuid.uuid4())[-12:])
-    _model = await controller.add_model(model_name)
+    _model = await controller.add_model(model_name,
+                                        cloud_name=os.getenv('PYTEST_CLOUD_NAME'),
+                                        region=os.getenv('PYTEST_CLOUD_REGION'),
+                                        )
     # https://github.com/juju/python-libjuju/issues/267
     subprocess.check_call(['juju', 'models'])
     while model_name not in await controller.list_models():

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -61,7 +61,7 @@ async def controller():
 @pytest.fixture(scope='module')
 async def model(controller):
     '''This model lives only for the duration of the test'''
-    model_name = "functest-{}".format(uuid.uuid4())
+    model_name = "functest-{}".format(str(uuid.uuid4())[-12:])
     _model = await controller.add_model(model_name)
     # https://github.com/juju/python-libjuju/issues/267
     subprocess.check_call(['juju', 'models'])

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -58,7 +58,7 @@ async def controller():
 
 
 @pytest.fixture(scope='module')
-async def model(controller):  # pylint: disable=redefined-outer-name
+async def model(controller):
     '''This model lives only for the duration of the test'''
     model_name = "functest-{}".format(uuid.uuid4())
     _model = await controller.add_model(model_name)
@@ -71,7 +71,7 @@ async def model(controller):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-async def get_app(model):  # pylint: disable=redefined-outer-name
+async def get_app(model):
     '''Returns the application requested'''
     async def _get_app(name):
         try:
@@ -82,7 +82,7 @@ async def get_app(model):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-async def get_unit(model):  # pylint: disable=redefined-outer-name
+async def get_unit(model):
     '''Returns the requested <app_name>/<unit_number> unit'''
     async def _get_unit(name):
         try:
@@ -94,7 +94,7 @@ async def get_unit(model):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-async def get_entity(get_unit, get_app):  # pylint: disable=redefined-outer-name
+async def get_entity(get_unit, get_app):
     '''Returns a unit or an application'''
     async def _get_entity(name):
         try:
@@ -108,7 +108,7 @@ async def get_entity(get_unit, get_app):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-async def run_command(get_unit):  # pylint: disable=redefined-outer-name
+async def run_command(get_unit):
     '''
     Runs a command on a unit.
 
@@ -127,7 +127,7 @@ async def run_command(get_unit):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-async def file_stat(run_command):  # pylint: disable=redefined-outer-name
+async def file_stat(run_command):
     '''
     Runs stat on a file
 
@@ -142,7 +142,7 @@ async def file_stat(run_command):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-async def file_contents(run_command):  # pylint: disable=redefined-outer-name
+async def file_contents(run_command):
     '''
     Returns the contents of a file
 
@@ -157,7 +157,7 @@ async def file_contents(run_command):  # pylint: disable=redefined-outer-name
 
 
 @pytest.fixture
-async def reconfigure_app(get_app, model):  # pylint: disable=redefined-outer-name
+async def reconfigure_app(get_app, model):
     '''Applies a different config to the requested app'''
     async def _reconfigure_app(cfg, target):
         application = (

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python3
+'''
+Reusable pytest fixtures for functional testing
+
+Environment variables
+---------------------
+
+test_preserve_model:
+if set, the testing model won't be torn down at the end of the testing session
+'''
+
+import asyncio
+import json
+import os
+import uuid
+import pytest
+import juju
+from juju.controller import Controller
+from juju.errors import JujuError
+
+STAT_CMD = '''python3 - <<EOF
+import json
+import os
+
+s = os.stat('%s')
+stat_hash = {
+    'uid': s.st_uid,
+    'gid': s.st_gid,
+    'mode': oct(s.st_mode),
+    'size': s.st_size
+}
+stat_json = json.dumps(stat_hash)
+print(stat_json)
+
+EOF
+'''
+
+
+@pytest.yield_fixture(scope='module')
+def event_loop():
+    '''Override the default pytest event loop to allow for fixtures using a
+    broader scope'''
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    asyncio.set_event_loop(loop)
+    loop.set_debug(True)
+    yield loop
+    loop.close()
+    asyncio.set_event_loop(None)
+
+
+@pytest.fixture(scope='module')
+async def controller():
+    '''Connect to the current controller'''
+    _controller = Controller()
+    await _controller.connect_current()
+    yield _controller
+    await _controller.disconnect()
+
+
+@pytest.fixture(scope='module')
+async def model(controller):  # pylint: disable=redefined-outer-name
+    '''This model lives only for the duration of the test'''
+    model_name = "functest-{}".format(uuid.uuid4())
+    _model = await controller.add_model(model_name)
+    yield _model
+    await _model.disconnect()
+    if not os.getenv('test_preserve_model'):
+        await controller.destroy_model(model_name)
+        while model_name in await controller.list_models():
+            await asyncio.sleep(1)
+
+
+@pytest.fixture
+async def get_app(model):  # pylint: disable=redefined-outer-name
+    '''Returns the application requested'''
+    async def _get_app(name):
+        try:
+            return model.applications[name]
+        except KeyError:
+            raise JujuError("Cannot find application {}".format(name))
+    return _get_app
+
+
+@pytest.fixture
+async def get_unit(model):  # pylint: disable=redefined-outer-name
+    '''Returns the requested <app_name>/<unit_number> unit'''
+    async def _get_unit(name):
+        try:
+            (app_name, unit_number) = name.split('/')
+            return model.applications[app_name].units[unit_number]
+        except (KeyError, ValueError):
+            raise JujuError("Cannot find unit {}".format(name))
+    return _get_unit
+
+
+@pytest.fixture
+async def get_entity(get_unit, get_app):  # pylint: disable=redefined-outer-name
+    '''Returns a unit or an application'''
+    async def _get_entity(name):
+        try:
+            return await get_unit(name)
+        except JujuError:
+            try:
+                return await get_app(name)
+            except JujuError:
+                raise JujuError("Cannot find entity {}".format(name))
+    return _get_entity
+
+
+@pytest.fixture
+async def run_command(get_unit):  # pylint: disable=redefined-outer-name
+    '''
+    Runs a command on a unit.
+
+    :param cmd: Command to be run
+    :param target: Unit object or unit name string
+    '''
+    async def _run_command(cmd, target):
+        unit = (
+            target
+            if isinstance(target, juju.unit.Unit)
+            else await get_unit(target)
+        )
+        action = await unit.run(cmd)
+        return action.results
+    return _run_command
+
+
+@pytest.fixture
+async def file_stat(run_command):  # pylint: disable=redefined-outer-name
+    '''
+    Runs stat on a file
+
+    :param path: File path
+    :param target: Unit object or unit name string
+    '''
+    async def _file_stat(path, target):
+        cmd = STAT_CMD % path
+        results = await run_command(cmd, target)
+        return json.loads(results['Stdout'])
+    return _file_stat
+
+
+@pytest.fixture
+async def file_contents(run_command):  # pylint: disable=redefined-outer-name
+    '''
+    Returns the contents of a file
+
+    :param path: File path
+    :param target: Unit object or unit name string
+    '''
+    async def _file_contents(path, target):
+        cmd = 'cat {}'.format(path)
+        results = await run_command(cmd, target)
+        return results['Stdout']
+    return _file_contents
+
+
+@pytest.fixture
+async def reconfigure_app(get_app, model):  # pylint: disable=redefined-outer-name
+    '''Applies a different config to the requested app'''
+    async def _reconfigure_app(cfg, target):
+        application = (
+            target
+            if isinstance(target, juju.application.Application)
+            else await get_app(target)
+        )
+        await application.set_config(cfg)
+        await application.get_config()
+        await model.block_until(lambda: application.status == 'active')
+    return _reconfigure_app

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -1,6 +1,5 @@
 import os
 import pytest
-from juju.model import Model
 
 # Treat all tests as coroutines
 pytestmark = pytest.mark.asyncio
@@ -37,9 +36,6 @@ async def test_${fixture}_deploy(model, series):
     await model.deploy('{}/builds/${metadata.package}'.format(juju_repository),
                        series=series,
                        application_name='${metadata.package}-{}'.format(series))
-    assert True
-
-
 #########
 # Tests #
 #########
@@ -49,7 +45,6 @@ async def test_${fixture}_status(apps, model):
     # Verifies status for all deployed series of the charm
     for app in apps:
         await model.block_until(lambda: app.status == 'active')
-    assert True
 
 
 async def test_example_action(units):

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -8,11 +8,7 @@ series = ['xenial', 'bionic']
 juju_repository = os.getenv('JUJU_REPOSITORY', '.').rstrip('/')
 
 
-###################
-# Custom fixtures #
-###################
-
-
+# Custom fixtures
 @pytest.fixture
 async def apps(model):
     apps = []
@@ -36,11 +32,9 @@ async def test_${fixture}_deploy(model, series):
     await model.deploy('{}/builds/${metadata.package}'.format(juju_repository),
                        series=series,
                        application_name='${metadata.package}-{}'.format(series))
-#########
-# Tests #
-#########
 
 
+# Tests
 async def test_${fixture}_status(apps, model):
     # Verifies status for all deployed series of the charm
     for app in apps:

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -45,10 +45,27 @@ async def test_${fixture}_deploy(model, series, source):
                            ])
 
 
+async def test_charm_upgrade(model, app):
+    if app.name.endswith('local'):
+        pytest.skip("No need to upgrade the local deploy")
+    unit = app.units[0]
+    await model.block_until(lambda: unit.agent_status == 'idle')
+    subprocess.check_call(['juju',
+                           'upgrade-charm',
+                           '--switch={}'.format(sources[0][1]),
+                           '-m', model.info.name,
+                           app.name,
+                           ])
+    unit = app.units[0]
+    await model.block_until(lambda: unit.agent_status == 'executing')
+
+
 # Tests
 async def test_${fixture}_status(model, app):
     # Verifies status for all deployed series of the charm
     await model.block_until(lambda: app.status == 'active')
+    unit = app.units[0]
+    await model.block_until(lambda: unit.agent_status == 'idle')
 
 
 async def test_example_action(app):

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -56,7 +56,6 @@ async def test_charm_upgrade(model, app):
                            '-m', model.info.name,
                            app.name,
                            ])
-    unit = app.units[0]
     await model.block_until(lambda: unit.agent_status == 'executing')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ passenv =
   HOME
   JUJU_REPOSITORY
   PATH
+  PYTEST_KEEP_MODEL
 commands = pytest -v --ignore {toxinidir}/tests/unit
 deps = -r{toxinidir}/tests/functional/requirements.txt
        -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -38,3 +38,5 @@ exclude =
     .git,
     __pycache__,
     .tox,
+max-line-length = 120
+max-complexity = 10

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ passenv =
   JUJU_REPOSITORY
   PATH
   PYTEST_KEEP_MODEL
+  PYTEST_CLOUD_NAME
+  PYTEST_CLOUD_REGION
 commands = pytest -v --ignore {toxinidir}/tests/unit
 deps = -r{toxinidir}/tests/functional/requirements.txt
        -r{toxinidir}/requirements.txt


### PR DESCRIPTION
This pulls in the functional test changes from LP, but also makes a relatively large change to how testing is done by introduction parameters for series and source of the charm. I've also made changes to make the testing JAAS compatible although I've only tested on Google Cloud.

I haven't tested all of the fixtures included I included them to stay as close as possible to the LP branch to eventually merge back there if this works well. I'm curious to look at how to better organize the fixtures or split some of them off into a module. I'm not sure that fixtures are the best solution for all of them but I didn't want to combine that with this merge and focused on the series testing and upgrades.
