### PR TITLE
Fix for all units being deployed as a single series in functional tests

### DIFF
--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -41,6 +41,7 @@ async def test_${fixture}_deploy(model, series, source):
                            'deploy',
                            source[1],
                            '-m', model.info.name,
+                           '--series', series,
                            application_name,
                            ])
 


### PR DESCRIPTION
Currently, the series parameter is not being passed to the juju deploy call, meaning the default series is used when deploying all units during functional testing. This merge fixes this.