### PR TITLE
Be meaner and crueler during linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,12 @@ deps = -r{toxinidir}/tests/functional/requirements.txt
 
 [testenv:lint]
 commands = flake8
-deps = flake8
+deps =
+    flake8
+    flake8-docstrings
+    flake8-import-order
+    pep8-naming
+    flake8-colors
 
 [flake8]
 exclude =


### PR DESCRIPTION
This merge adds, to the default linting:
- Docstring checking
- Import order checking
- PEP8 naming checks
- Colours