### PR TITLE
Add pytest-timeout for functional tests

### DIFF
--- a/tests/functional/requirements.txt
+++ b/tests/functional/requirements.txt
@@ -3,4 +3,5 @@ juju
 mock
 pytest
 pytest-asyncio
+pytest-timeout
 requests

--- a/tests/functional/test_deploy.py
+++ b/tests/functional/test_deploy.py
@@ -18,16 +18,6 @@ sources = [
 ]
 
 
-# Uncomment for re-using the current model, useful for debugging functional tests
-# @pytest.fixture(scope='module')
-# async def model():
-#     from juju.model import Model
-#     model = Model()
-#     await model.connect_current()
-#     yield model
-#     await model.disconnect()
-
-
 # Custom fixtures
 @pytest.fixture(params=series)
 def series(request):
@@ -61,6 +51,7 @@ async def test_${fixture}_deploy(model, series, source, request):
 
 
 @pytest.mark.deploy
+@pytest.mark.timeout(300)
 async def test_charm_upgrade(model, app):
     if app.name.endswith("local"):
         pytest.skip("No need to upgrade the local deploy")
@@ -80,6 +71,7 @@ async def test_charm_upgrade(model, app):
 
 
 @pytest.mark.deploy
+@pytest.mark.timeout(300)
 async def test_${fixture}_status(model, app):
     # Verifies status for all deployed series of the charm
     await model.block_until(lambda: app.status == 'active')

--- a/tox.ini
+++ b/tox.ini
@@ -55,5 +55,5 @@ max-line-length = 120
 max-complexity = 10
 
 [pytest]
-marks=
+markers =
     deploy: mark deployment tests to allow running w/o redeploy


### PR DESCRIPTION
* Added pytest-timeout plugin to functional test
* Set a 300 second timeout for deployment/upgrade
* Removed unused comments in test_deploy